### PR TITLE
removed google-resumable-media requirment

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,3 @@ six==1.14.0
 SQLAlchemy==1.3.15
 urllib3==1.25.8
 typing===3.7.4.1
-
-# at one point it was necessary to downgrade google-resumable-medio to 0.5.0. A later version (1.1.0) was already in requirment-gcp.txt. For now, we are ignoring the version below and going with the version in requirements-gcp. We can revisit this issue if future problems develop. 
-# google-resumable-media==0.5.0


### PR DESCRIPTION
There was confusion over which version GRM was needed for the pipelines, and the version here was added in error. I am removing the requirement and the notation around it. Thanks!