### PR TITLE
Add time conversion dataflow_util

### DIFF
--- a/dags/dependencies/dataflow_scripts/dataflow_utils/dataflow_utils.py
+++ b/dags/dependencies/dataflow_scripts/dataflow_utils/dataflow_utils.py
@@ -141,10 +141,11 @@ class StandardizeTimes(beam.DoFn, ABC):
         """
         :param time_changes: list of tuples; each tuple consists of an existing field name containing date strings +
         the name of the timezone the given date string belongs to.
-        The function takes in date string values and standardizes them to datetimes in UTC, EST, and Unix.
+        The function takes in date string values and standardizes them to datetimes in UTC, Eastern, and Unix.
         formats. It is powerful enough to handle datetimes in a variety of timezones and string formats.
         The user must provide a timezone name contained within pytz.all_timezones.
-        A list of accepted timezones can be found on https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List
+        As of June 2021, a list of accepted timezones can be found on https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List
+        Please note that the timezone names are subject to change and the code would have to be updated accordingly. (JF)
         """
         self.time_changes = time_changes
 
@@ -159,7 +160,7 @@ class StandardizeTimes(beam.DoFn, ABC):
             else:
                 loc_time = pytz.timezone(time_change[1]).localize(clean_dt, is_dst=None)
                 utc_conv = loc_time.astimezone(tz=pytz.utc)
-                east_conv = loc_time.astimezone(tz=pytz.timezone('US/Eastern'))
+                east_conv = loc_time.astimezone(tz=pytz.timezone('America/New_York'))
                 unix_conv = utc_conv.timestamp()
                 datum.update({'{}_UTC'.format(time_change[0]): str(utc_conv),
                               '{}_EAST'.format(time_change[0]): str(east_conv),

--- a/dags/dependencies/dataflow_scripts/dataflow_utils/dataflow_utils.py
+++ b/dags/dependencies/dataflow_scripts/dataflow_utils/dataflow_utils.py
@@ -159,10 +159,10 @@ class StandardizeTimes(beam.DoFn, ABC):
             else:
                 loc_time = pytz.timezone(time_change[1]).localize(clean_dt, is_dst=None)
                 utc_conv = loc_time.astimezone(tz=pytz.utc)
-                est_conv = loc_time.astimezone(tz=pytz.timezone('US/Eastern'))
+                east_conv = loc_time.astimezone(tz=pytz.timezone('US/Eastern'))
                 unix_conv = utc_conv.timestamp()
                 datum.update({'{}_UTC'.format(time_change[0]): str(utc_conv),
-                              '{}_EST'.format(time_change[0]): str(est_conv),
+                              '{}_EAST'.format(time_change[0]): str(east_conv),
                               '{}_UNIX'.format(time_change[0]): unix_conv})
 
         yield datum

--- a/dags/dependencies/dataflow_scripts/dataflow_utils/dataflow_utils.py
+++ b/dags/dependencies/dataflow_scripts/dataflow_utils/dataflow_utils.py
@@ -30,13 +30,10 @@ DEFAULT_DATAFLOW_ARGS = [
     '--save_main_session',
 ]
 
-TZ_CONVERTER = {'East': 'US/Eastern', 'Eastern': 'US/Eastern', 'Pittsburgh': 'US/Eastern',
-                'Pennsylvania': 'US/Eastern', 'New York': 'US/Eastern', 'America/New_York': 'US/Eastern',
-                'EST': 'US/Eastern', 'EDT': 'US/Eastern', 'US/Eastern': 'US/Eastern',
-                'Mountain': 'America/Denver', 'MST': 'America/Denver', 'America/Denver': 'America/Denver',
-                'Europe': 'Europe/London', 'EU': 'Europe/London', 'London': 'Europe/London', 'UK': 'Europe/London',
-                'England': 'Europe/London', 'Britain': 'Europe/London', 'Europe/London': 'Europe/London',
-                'Universal': 'UTC', 'Standard': 'UTC', 'GMT': 'UTC', 'UTC': 'UTC'}
+TZ_CONVERTER =      dict.fromkeys(['East', 'Eastern', 'Pittsburgh', 'Pennsylvania', 'New York', 'America/New_York','US/Eastern', 'EDT', 'EST'], 'US/Eastern')
+TZ_CONVERTER.update(dict.fromkeys(['Mountain', 'MST', 'America/Denver'], 'America/Denver'))
+TZ_CONVERTER.update(dict.fromkeys(['Europe', 'EU', 'London', 'UK', 'England', 'Britain', 'Europe/London'], 'Europe/London'))
+TZ_CONVERTER.update(dict.fromkeys(['Universal', 'Standard', 'GMT', 'UTC'], 'UTC'))
 
 
 class JsonCoder(object):
@@ -162,9 +159,9 @@ class StandardizeTimes(beam.DoFn, ABC):
             utc_conv = loc_time.astimezone(tz=pytz.utc)
             est_conv = loc_time.astimezone(tz=pytz.timezone('US/Eastern'))
             unix_conv = utc_conv.timestamp()
-            datum.update({'{}_UTC'.format(time_change[0]): utc_conv,
-                          '{}_EST'.format(time_change[0]): est_conv,
-                          '{}_UNIX'.format(time_change[0]): unix_conv})
+            datum.update({'{}_UTC'.format(time_change[0]): str(utc_conv),
+                          '{}_EST'.format(time_change[0]): str(est_conv),
+                          '{}_UNIX'.format(time_change[0]): unix_conv })
 
         yield datum
 

--- a/tests/test_dataflow_utils.py
+++ b/tests/test_dataflow_utils.py
@@ -86,6 +86,17 @@ class TestDataflowUtils(unittest.TestCase):
         self.assertEqual(next(ff.process(datum)), expected)
 
     def test_standardize_times(self):
+        """
+        Author : Jason Ficorilli
+        Date   : June 2021
+        This test function confirms that the StandardizeTimes utility function will successfully strip the
+        timezone from a timestring input and instead localize the times using the timezone name
+        provided by the developer.
+        This test case was developed with the purpose of verifying that StandardizeTimes would still work if
+        provided with conflicting information. The two timestrings provided in the datum dictionary include
+        timezone definitions (UTC, -04:00) that contradict the timezone names that are passed into the
+        StandardizeTimes utility function (America/Denver, UTC).
+        """
         datum = {'openedDate': 'Fri July 19 03:21:55 UTC 2019', 'closedDate': '2021-05-01 01:44:00-04:00'}
         params = [('openedDate', 'America/Denver'), ('closedDate', 'UTC')]
         expected = datum.copy()
@@ -99,6 +110,14 @@ class TestDataflowUtils(unittest.TestCase):
         self.assertEqual(next(tst.process(datum)), expected)
 
     def test_standardize_times_with_api(self):
+        """
+        Author : Pranav Banthia
+        Date   : June 2021
+        For this test function, we use the current date which is datetime.now() as the starting point and then subtract
+        a random timedelta from it to have multiple combinations of date/hour/minute values.
+        Every timestamp is formatted in a different timezone/datetime format to ensure robustness of our dataflow util
+        function. Since we have randomly generated timestamps, we use a third part API to create our expected test string.
+        """
         # replacing the second and microsecond ensures that the unix timestamp is not a floating point number
         datetime_ = datetime.datetime.now().replace(second=0, microsecond=0)
 
@@ -116,7 +135,7 @@ class TestDataflowUtils(unittest.TestCase):
         for i in range(0, 8):
             # We subtract a timedelta of 5000 minutes to ensure we have a different combination of hour/minute/day and
             # date for every iteration
-            datetime_ -= datetime.timedelta(minutes=5000)
+            datetime_ -= datetime.timedelta(minutes=np.random.randint(low = 1000, high = 50000))
 
             # To find the UTC-EST offset we first localize the current time to eastern zone and then calculate the
             # offset. This is done only to ensures we take into account the daylight savings time

--- a/tests/test_dataflow_utils.py
+++ b/tests/test_dataflow_utils.py
@@ -87,13 +87,13 @@ class TestDataflowUtils(unittest.TestCase):
 
     def test_standardize_times(self):
         datum = {'openedDate': 'Fri July 19 03:21:55 UTC 2019', 'closedDate': '2021-05-01 01:44:00-04:00'}
-        params = [('openedDate', 'Mountain'), ('closedDate', 'UTC')]
+        params = [('openedDate', 'America/Denver'), ('closedDate', 'UTC')]
         expected = datum.copy()
-        expected.update(dict(openedDate_UTC=parser.parse('2019-07-19 09:21:55+00:00'),
-                             openedDate_EST=parser.parse('2019-07-19 05:21:55-04:00'),
+        expected.update(dict(openedDate_UTC='2019-07-19 09:21:55+00:00',
+                             openedDate_EST='2019-07-19 05:21:55-04:00',
                              openedDate_UNIX=1563528115.0,
-                             closedDate_UTC=parser.parse('2021-05-01 01:44:00+00:00'),
-                             closedDate_EST=parser.parse('2021-04-30 21:44:00-04:00'),
+                             closedDate_UTC='2021-05-01 01:44:00+00:00',
+                             closedDate_EST='2021-04-30 21:44:00-04:00',
                              closedDate_UNIX=1619833440.0))
         tst = dataflow_utils.StandardizeTimes(params)
         self.assertEqual(next(tst.process(datum)), expected)
@@ -109,8 +109,7 @@ class TestDataflowUtils(unittest.TestCase):
 
         for i in range(0, 8):
             datetime_ -= datetime.timedelta(minutes=5000)
-            conv_tz = dataflow_utils.TZ_CONVERTER[time_zones_[i]]
-            loc_time = pytz.timezone(conv_tz).localize(datetime_, is_dst=None)
+            loc_time = pytz.timezone(time_zones_[i]).localize(datetime_, is_dst=None)
             formatted_loc_time = loc_time.strftime(dt_formats[i])
             datum = {'openedDate': formatted_loc_time}
             param = [('openedDate', time_zones_[i])]

--- a/tests/test_dataflow_utils.py
+++ b/tests/test_dataflow_utils.py
@@ -1,11 +1,16 @@
 from __future__ import absolute_import
 from __future__ import division
 # patches unittest.TestCase to be python3 compatible
+import datetime
+
 import future.tests.base  # pylint: disable=unused-import
 import unittest
 import numpy as np
+import requests
 
+from dateutil import parser
 from dataflow_utils import dataflow_utils
+import pytz
 
 
 class TestDataflowUtils(unittest.TestCase):
@@ -16,14 +21,12 @@ class TestDataflowUtils(unittest.TestCase):
         ccsc = dataflow_utils.ColumnsCamelToSnakeCase()
         self.assertEqual(next(ccsc.process(datum)), expected)
 
-
     def test_columns_to_lower_case(self):
         datum = {'Example_Column': 'foo', 'anotherExample': 'bar', 'With a Space': 'foo'}
         expected = {'example_column': 'foo', 'anotherexample': 'bar', 'with a space': 'foo'}
         clc = dataflow_utils.ColumnsToLowerCase()
         self.assertEqual(next(clc.process(datum)), expected)
 
-    
     def test_change_data_types(self):
         datum = {'count': '1', 'zip': 15213, 'temp': 72, 'day': 31.1,
                  'bool1': 'TRUE', 'bool2': 1, 'nan_float': np.nan, 'nan_int': np.nan, 'nan_str': np.nan}
@@ -81,6 +84,54 @@ class TestDataflowUtils(unittest.TestCase):
         expected = {'state': 'pa'}
         ff = dataflow_utils.FilterFields(relevant_fields, exclude_relevant_fields=False)
         self.assertEqual(next(ff.process(datum)), expected)
+
+    def test_standardize_times(self):
+        datum = {'openedDate': 'Fri July 19 03:21:55 UTC 2019', 'closedDate': '2021-05-01 01:44:00-04:00'}
+        params = [('openedDate', 'Mountain'), ('closedDate', 'UTC')]
+        expected = datum.copy()
+        expected.update(dict(openedDate_UTC=parser.parse('2019-07-19 09:21:55+00:00'),
+                             openedDate_EST=parser.parse('2019-07-19 05:21:55-04:00'),
+                             openedDate_UNIX=1563528115.0,
+                             closedDate_UTC=parser.parse('2021-05-01 01:44:00+00:00'),
+                             closedDate_EST=parser.parse('2021-04-30 21:44:00-04:00'),
+                             closedDate_UNIX=1619833440.0))
+        tst = dataflow_utils.StandardizeTimes(params)
+        self.assertEqual(next(tst.process(datum)), expected)
+
+    def test_standardize_times_with_api(self):
+        datetime_ = datetime.datetime.now().replace(second=0, microsecond=0)
+        time_zones_ = ['Mountain', 'Eastern', 'Universal', 'EU', 'New York', 'GMT', 'MST', 'Britain']
+        dt_formats = ["%Y-%m-%dT%H:%M:%S", "%Y/%m/%d %H:%M:%S %z", "%Y.%m.%d %H:%M:%S", "%a %B %d %H:%M:%S %Z %Y",
+                      "%a %B %d %H:%M:%S %Y", "%c", "%d %b, %Y %H:%M:%S", "%m/%d/%Y, %H:%M:%S"]
+
+        date_to_unix_ = "https://showcase.api.linx.twenty57.net/UnixTime/tounix"
+        unix_to_timezone_ = "https://showcase.api.linx.twenty57.net/UnixTime/fromunixtimestamp"
+
+        for i in range(0, 8):
+            datetime_ -= datetime.timedelta(minutes=5000)
+            conv_tz = dataflow_utils.TZ_CONVERTER[time_zones_[i]]
+            loc_time = pytz.timezone(conv_tz).localize(datetime_, is_dst=None)
+            formatted_loc_time = loc_time.strftime(dt_formats[i])
+            datum = {'openedDate': formatted_loc_time}
+            param = [('openedDate', time_zones_[i])]
+
+            api_request_unix = requests.get(url=date_to_unix_,
+                                            params={'date': loc_time})
+            api_request_est = requests.post(url=unix_to_timezone_,
+                                            json={"UnixTimeStamp": api_request_unix.json(), "Timezone": "-4"})
+            api_request_utc = requests.post(url=unix_to_timezone_,
+                                            json={"UnixTimeStamp": api_request_unix.json(), "Timezone": ""})
+
+            utc_time = datetime.datetime.strptime(str(api_request_utc.json()['Datetime']), "%Y-%m-%dT%H:%M:%S%z")
+            est_time = datetime.datetime.strptime(str(api_request_est.json()['Datetime']), "%Y-%m-%dT%H:%M:%S%z")
+
+            expected = dict(openedDate=str(formatted_loc_time),
+                            openedDate_UNIX=float(api_request_unix.json()),
+                            openedDate_UTC=str(utc_time),
+                            openedDate_EST=str(est_time))
+
+            tst = dataflow_utils.StandardizeTimes(param)
+            self.assertEqual(next(tst.process(datum)), expected)
 
 
 if __name__ == '__main__':

--- a/tests/test_dataflow_utils.py
+++ b/tests/test_dataflow_utils.py
@@ -99,28 +99,45 @@ class TestDataflowUtils(unittest.TestCase):
         self.assertEqual(next(tst.process(datum)), expected)
 
     def test_standardize_times_with_api(self):
-        datetime_ = datetime.datetime.now().replace(second=0, microsecond=0)
-        time_zones_ = ['Mountain', 'Eastern', 'Universal', 'EU', 'New York', 'GMT', 'MST', 'Britain']
-        dt_formats = ["%Y-%m-%dT%H:%M:%S", "%Y/%m/%d %H:%M:%S %z", "%Y.%m.%d %H:%M:%S", "%a %B %d %H:%M:%S %Z %Y",
-                      "%a %B %d %H:%M:%S %Y", "%c", "%d %b, %Y %H:%M:%S", "%m/%d/%Y, %H:%M:%S"]
+        # replacing the second and microsecond ensures that the unix timestamp is not a floating point number
+        datetime_         = datetime.datetime.now().replace(second=0, microsecond=0)
 
-        date_to_unix_ = "https://showcase.api.linx.twenty57.net/UnixTime/tounix"
+        # Pre-defining a list of different acceptable time zones and date time formats to ensure our function is capable
+        # of handling any input format
+        time_zones_       = ['America/Denver', 'America/New_York', 'UTC', 'Europe/London', 'America/New_York', 'GMT',
+                             'America/Denver', 'Europe/London']
+        dt_formats        = ["%Y-%m-%dT%H:%M:%S", "%Y/%m/%d %H:%M:%S %z", "%Y.%m.%d %H:%M:%S", "%a %B %d %H:%M:%S %Z %Y"
+                             , "%a %B %d %H:%M:%S %Y", "%c", "%d %b, %Y %H:%M:%S", "%m/%d/%Y, %H:%M:%S"]
+
+        # API Endpoints
+        date_to_unix_     = "https://showcase.api.linx.twenty57.net/UnixTime/tounix"
         unix_to_timezone_ = "https://showcase.api.linx.twenty57.net/UnixTime/fromunixtimestamp"
 
         for i in range(0, 8):
-            datetime_ -= datetime.timedelta(minutes=5000)
-            loc_time = pytz.timezone(time_zones_[i]).localize(datetime_, is_dst=None)
-            formatted_loc_time = loc_time.strftime(dt_formats[i])
-            datum = {'openedDate': formatted_loc_time}
-            param = [('openedDate', time_zones_[i])]
+            # We subtract a timedelta of 5000 minutes to ensure we have a different combination of hour/minute/day and
+            # date for every iteration
+            datetime_         -= datetime.timedelta(minutes=5000)
 
+            # To find the UTC-EST offset we first localize the current time to eastern zone and then calculate the
+            # offset. This is done only to ensures we take into account the daylight savings time
+            _loc_time          = pytz.timezone("America/New_York").localize(datetime_, is_dst=None)
+            est_utc_offset     = str(int(_loc_time.utcoffset().total_seconds() / 60 / 60))
+
+            # Finally we localize the datetime object to the test timezones which are defined above
+            loc_time           = pytz.timezone(time_zones_[i]).localize(datetime_, is_dst=None)
+            formatted_loc_time = loc_time.strftime(dt_formats[i])
+            datum              = {'openedDate': formatted_loc_time}
+            param              = [('openedDate', time_zones_[i])]
+
+            # API calls to get the unix timestamp, eastern time and UTC time respectively for the given datetime object
             api_request_unix = requests.get(url=date_to_unix_,
                                             params={'date': loc_time})
-            api_request_est = requests.post(url=unix_to_timezone_,
-                                            json={"UnixTimeStamp": api_request_unix.json(), "Timezone": "-4"})
-            api_request_utc = requests.post(url=unix_to_timezone_,
-                                            json={"UnixTimeStamp": api_request_unix.json(), "Timezone": ""})
+            api_request_est  = requests.post(url=unix_to_timezone_,
+                                             json={"UnixTimeStamp": api_request_unix.json(), "Timezone":est_utc_offset})
+            api_request_utc  = requests.post(url=unix_to_timezone_,
+                                             json={"UnixTimeStamp": api_request_unix.json(), "Timezone": ""})
 
+            # Formatting the output the way it would be returned from the dataflow_utils function
             utc_time = datetime.datetime.strptime(str(api_request_utc.json()['Datetime']), "%Y-%m-%dT%H:%M:%S%z")
             est_time = datetime.datetime.strptime(str(api_request_est.json()['Datetime']), "%Y-%m-%dT%H:%M:%S%z")
 
@@ -129,6 +146,7 @@ class TestDataflowUtils(unittest.TestCase):
                             openedDate_UTC=str(utc_time),
                             openedDate_EST=str(est_time))
 
+            # Test our expected output against the values returned from dataflow utils standardize times
             tst = dataflow_utils.StandardizeTimes(param)
             self.assertEqual(next(tst.process(datum)), expected)
 


### PR DESCRIPTION
This commit adds a new class to dataflow_utils that takes in datetime
string values and standardizes them to datetimes in UTC, EST, and Unix
formats. It is powerful enough to handle datetimes in a variety of
timezones and string formats.