### PR TITLE
Refactor PII Scrubbing to Occur in Dataflow

### DIFF
--- a/af2_dags/computronix_gis_street_closures_airflow.py
+++ b/af2_dags/computronix_gis_street_closures_airflow.py
@@ -60,7 +60,7 @@ gcs_to_bq = GoogleCloudStorageToBigQueryOperator(
 )
 
 
-# Export table as CSV to WPRDC bucket
+# Export table as CSV to data-bridGIS bucket
 # file name is the date. path contains the date info
 csv_file_name = f"{path}"
 dest_bucket = f"gs://pghpa_{dataset}/street_segments/"

--- a/af2_dags/dependencies/dataflow_scripts/dataflow_utils/dataflow_utils.py
+++ b/af2_dags/dependencies/dataflow_scripts/dataflow_utils/dataflow_utils.py
@@ -959,7 +959,10 @@ def replace_pii(datum, input_field, retain_location, info_types, gcloud_project,
     try:
         input_str = datum[input_field]
     except TypeError:
-        print("what gives")
+        print("Error extracting value from " + str(input_field) + " field")
+        input_str = ""
+    if not input_str:
+        input_str = "No comment"
     if retain_location:
         input_str = snake_case_place_names(input_str, place_id_bucket)
 

--- a/af2_dags/dependencies/dataflow_scripts/dataflow_utils/dataflow_utils.py
+++ b/af2_dags/dependencies/dataflow_scripts/dataflow_utils/dataflow_utils.py
@@ -19,11 +19,14 @@ from dateutil import parser
 import apache_beam as beam
 from apache_beam.options.pipeline_options import PipelineOptions
 
-from google.cloud import bigquery, storage
+from google.cloud import bigquery, storage, dlp
 
 dt = datetime.now()
 bq_client = bigquery.Client()
 storage_client = storage.Client()
+dlp_client = dlp.DlpServiceClient()
+
+USER_DEFINED_CONST_BUCKET = "user_defined_data"
 
 
 class JsonCoder(object):
@@ -416,6 +419,29 @@ class ReformatPhoneNumbers(beam.DoFn, ABC):
             yield "+" + digits[:-10] + " (%s) %s-%s" % tuple(re.findall(regex, digits[-10:]))
         else:
             yield "+1" + " (%s) %s-%s" % tuple(re.findall(regex, digits))
+
+
+class RemovePII(beam.DoFn):
+    """
+    Comments must be scrubbed for PII from 311 requests.
+    Comments do not follow strict formatting so this is an imperfect approximation.
+    Steps: extract fields, detect person names that are followed by hotwords for exclusion (e.g. park or street),
+    place an underscore between the detected words to prevent accidental redaction, redact PII
+    The Google data loss prevention (dlp) API is used (via helper function) to scrub PII
+    """
+    def __init__(self, input_field, new_field_name, retain_location: bool, info_types):
+        self.input_field = input_field
+        self.new_field_name = new_field_name
+        self.retain_location = retain_location
+        self.info_types = info_types
+
+    def process(self, datum):
+        if datum is not None:
+            datum[self.new_field_name] = replace_pii(datum, self.input_field, self.retain_location, self.info_types)
+
+            yield datum
+        else:
+            logging.info('got NoneType datum')
 
 
 class StandardizeTimes(beam.DoFn, ABC):
@@ -924,6 +950,60 @@ def filter_fields(datum, target_fields, exclude_target_fields = True):
             datum.pop(field, None)
 
     return datum
+
+
+def replace_pii(datum, input_field, retain_location, info_types):
+    try:
+        input_str = datum[input_field]
+    except TypeError:
+        print("what gives")
+    if retain_location:
+        input_str = snake_case_place_names(input_str)
+
+    item = {"value": input_str}
+    max_findings = 0
+    include_quote = False
+    inspect_config = {
+        "info_types": info_types,
+        "include_quote": include_quote,
+        "limits": {"max_findings_per_request": max_findings},
+    }
+    deidentify_config = {
+        "info_type_transformations": {
+            "transformations": [
+                {"primitive_transformation": {"replace_with_info_type_config": {}}}
+            ]
+        }
+    }
+    parent = "projects/{}".format(os.environ['GCLOUD_PROJECT'])
+
+    response = dlp_client.deidentify_content(parent, deidentify_config, inspect_config, item)
+
+    return response.item.value
+
+
+def snake_case_place_names(input):
+    # Helper function to take a pair of words, containing place name identifiers, and join them together (with an
+    # underscore by default). This prevents NLP based Data Loss Prevention/PII scrubbers from targeting places for
+    # name based redaction (e.g. avoiding redacting "Schenley" from "Schenley Park"), because the GCP tools will not
+    # treat the joined phrase as person's name. This approach should be phased out after a less brittle and more elegant
+    # tool is developed.
+
+    bucket = storage_client.get_bucket(USER_DEFINED_CONST_BUCKET)
+    blob = bucket.blob('place_identifiers.txt')
+    place_name_identifiers = blob.download_as_string().decode('utf-8')
+
+    street_num_blob = bucket.blob('street_num_identifiers.txt')
+    street_num_identifiers = street_num_blob.download_as_string().decode('utf-8')
+
+    # if an identifier is found (indicative of a place such as a road or park), we want to join the place with the
+    # preceding word with the join character. Thus, "Moore Park" would become "Moore_Park".
+    joined_places = (re.sub(r'(\s)\b({})\b'.format(place_name_identifiers), r'_\2', input,
+                            flags=re.IGNORECASE))
+    joined_places = (re.sub(r'\b({})\b(\s)'.format(street_num_identifiers), r'\1_', joined_places,
+                            flags=re.IGNORECASE))
+
+    return joined_places
 
 
 def sort_dict(d):

--- a/af2_dags/dependencies/dataflow_scripts/qalert_requests_dataflow.py
+++ b/af2_dags/dependencies/dataflow_scripts/qalert_requests_dataflow.py
@@ -10,7 +10,7 @@ from apache_beam.io.avroio import WriteToAvro
 from dataflow_utils import dataflow_utils
 from dataflow_utils.dataflow_utils import JsonCoder, SwapFieldNames, generate_args, FilterFields, \
     ColumnsCamelToSnakeCase, GetDateStringsFromUnix, ChangeDataTypes, unix_to_date_strings, \
-    FormatAndClassifyAddress, GoogleMapsGeocodeAddress, AnonymizeAddressBlock, AnonymizeLatLong
+    FormatAndClassifyAddress, GoogleMapsGeocodeAddress, AnonymizeAddressBlock, AnonymizeLatLong, RemovePII
 
 DEFAULT_DATAFLOW_ARGS = [
         '--save_main_session',
@@ -18,6 +18,12 @@ DEFAULT_DATAFLOW_ARGS = [
         f"--service_account_email={os.environ['SERVICE_ACCT']}",
         f"--region={os.environ['REGION']}",
         f"--subnetwork={os.environ['SUBNET']}"
+]
+
+DEFAULT_PII_TYPES = [
+    {"name": "PERSON_NAME"},
+    {"name": "EMAIL_ADDRESS"},
+    {"name": "PHONE_NUMBER"}
 ]
 
 class GetStatus(beam.DoFn):
@@ -63,7 +69,7 @@ def run(argv = None):
             job_name = 'qalert-requests-dataflow',
             bucket = f"{os.environ['GCS_PREFIX']}_qalert",
             argv = argv,
-            schema_name = 'qalert_requests_enriched',
+            schema_name = 'af2_qalert_requests',
             default_arguments=DEFAULT_DATAFLOW_ARGS,
             limit_workers = [False, None]
     )
@@ -72,15 +78,15 @@ def run(argv = None):
         field_name_swaps = [('master', 'parent_ticket_id'),
                             ('addDateUnix', 'create_date_unix'),
                             ('lastActionUnix', 'last_action_unix'),
-                            ("status", "status_code"),
+                            ('status', 'status_code'),
                             ('streetNum', 'pii_street_num'),
                             ('streetName', 'street'),
-                            ("crossStreetName", "cross_street"),
-                            ("comments", "pii_comments"),
-                            ("privateNotes", "pii_private_notes"),
-                            ("latitude", "pii_lat"),
-                            ("longitude", "pii_long"),
-                            ("cityName", "city"),
+                            ('crossStreetName', 'cross_street'),
+                            ('comments', 'pii_comments'),
+                            ('privateNotes', 'pii_private_notes'),
+                            ('latitude', 'pii_lat'),
+                            ('longitude', 'pii_long'),
+                            ('cityName', 'city'),
                             ('typeId', 'request_type_id'),
                             ('typeName', 'request_type_name')]
 
@@ -119,6 +125,7 @@ def run(argv = None):
 
         load = (
                 lines
+                | beam.ParDo(RemovePII('comments', 'anon_comments', True, DEFAULT_PII_TYPES))
                 | beam.ParDo(SwapFieldNames(field_name_swaps))
                 | beam.ParDo(FilterFields(drop_fields))
                 | beam.ParDo(ColumnsCamelToSnakeCase())

--- a/af2_dags/dependencies/dataflow_scripts/qalert_requests_dataflow.py
+++ b/af2_dags/dependencies/dataflow_scripts/qalert_requests_dataflow.py
@@ -10,7 +10,7 @@ from apache_beam.io.avroio import WriteToAvro
 from dataflow_utils import dataflow_utils
 from dataflow_utils.dataflow_utils import JsonCoder, SwapFieldNames, generate_args, FilterFields, \
     ColumnsCamelToSnakeCase, GetDateStringsFromUnix, ChangeDataTypes, unix_to_date_strings, \
-    FormatAndClassifyAddress, GoogleMapsGeocodeAddress, AnonymizeAddressBlock, AnonymizeLatLong, RemovePII
+    FormatAndClassifyAddress, GoogleMapsGeocodeAddress, AnonymizeAddressBlock, AnonymizeLatLong, ReplacePII
 
 DEFAULT_DATAFLOW_ARGS = [
         '--save_main_session',
@@ -25,6 +25,8 @@ DEFAULT_PII_TYPES = [
     {"name": "EMAIL_ADDRESS"},
     {"name": "PHONE_NUMBER"}
 ]
+
+USER_DEFINED_CONST_BUCKET = "user_defined_data"
 
 class GetStatus(beam.DoFn):
     def process(self, datum):
@@ -125,7 +127,8 @@ def run(argv = None):
 
         load = (
                 lines
-                | beam.ParDo(RemovePII('comments', 'anon_comments', True, DEFAULT_PII_TYPES))
+                | beam.ParDo(ReplacePII('comments', 'anon_comments', True, DEFAULT_PII_TYPES,
+                                        os.environ['GCLOUD_PROJECT'], USER_DEFINED_CONST_BUCKET))
                 | beam.ParDo(SwapFieldNames(field_name_swaps))
                 | beam.ParDo(FilterFields(drop_fields))
                 | beam.ParDo(ColumnsCamelToSnakeCase())

--- a/af2_dags/dependencies/gcs_loaders/qalert_requests_gcs.py
+++ b/af2_dags/dependencies/gcs_loaders/qalert_requests_gcs.py
@@ -30,7 +30,7 @@ run_start_win, first_run = find_last_successful_run(bucket, "requests/successful
 
 # qscend API requires a value (any value) for the user-agent field
 headers = {'User-Agent': 'City of Pittsburgh ETL'}
-payload = {'key': os.environ['QALERT_KEY'], 'since': "2022-08-24 19:00:00"} #run_start_win}
+payload = {'key': os.environ['QALERT_KEY'], 'since': run_start_win}
 
 
 # continue running the API until data is retrieved (wait 5 min if there is no new data between last_good_run and now (

--- a/af2_dags/dependencies/gcs_loaders/qalert_requests_gcs.py
+++ b/af2_dags/dependencies/gcs_loaders/qalert_requests_gcs.py
@@ -104,6 +104,7 @@ for i in range(len(full_requests)):
         success = True
     except:
         print("Error at ticket index #" + str(i))
+        print("Full request list length: " + str(len(full_requests)) + "| Scrubbed comment list length: " + str(len(all_comms)))
         success = False
         break
 

--- a/af2_dags/dependencies/gcs_loaders/qalert_requests_gcs.py
+++ b/af2_dags/dependencies/gcs_loaders/qalert_requests_gcs.py
@@ -23,7 +23,7 @@ args = vars(parser.parse_args())
 # payload below
 yesterday = datetime.combine(datetime.now(tz = pendulum.timezone("utc")) - timedelta(1),
                              datetime.min.time()).strftime("%Y-%m-%d %H:%M:%S")
-run_start_win, first_run = find_last_successful_run(bucket, "requests/successful_run_log/log.json", yesterday)
+run_start_win, first_run = find_last_successful_run(bucket, "requests/comment_refactor/successful_run_log/log.json", yesterday)
 
 
 # qscend API requires a value (any value) for the user-agent field
@@ -58,7 +58,7 @@ successful_run = [{"requests_retrieved": len(full_requests),
                    "since": run_start_win,
                    "current_run": curr_run,
                    "note": "Data retrieved between the time points listed above"}]
-json_to_gcs("requests/successful_run_log/log.json", successful_run,
+json_to_gcs("requests/comment_refactor/successful_run_log/log.json", successful_run,
             bucket)
 
 # load to gcs

--- a/af2_dags/dependencies/gcs_loaders/qalert_requests_gcs.py
+++ b/af2_dags/dependencies/gcs_loaders/qalert_requests_gcs.py
@@ -98,15 +98,12 @@ for b in pre_clean_batches:
 
 # overwrite the original fields with scrubbed data
 success = False
-if len(full_requests) == len(all_comms):
-    for i in range(len(full_requests)):
-        try:
-            full_requests[i]["comments"] = all_comms[i].strip()
-            success = True
-        except:
-            print("Error at ticket index #" + str(i))
-else:
-    print("Error: mismatch in comment list sizes")
+for i in range(len(full_requests)):
+    try:
+        full_requests[i]["comments"] = all_comms[i].strip()
+        success = True
+    except:
+        print("Error at ticket index #" + str(i))
 
 
 # write the successful run information (used by each successive DAG run to find the backfill date)

--- a/af2_dags/dependencies/gcs_loaders/qalert_requests_gcs.py
+++ b/af2_dags/dependencies/gcs_loaders/qalert_requests_gcs.py
@@ -104,6 +104,8 @@ for i in range(len(full_requests)):
         success = True
     except:
         print("Error at ticket index #" + str(i))
+        success = False
+        break
 
 
 # write the successful run information (used by each successive DAG run to find the backfill date)

--- a/af2_dags/dependencies/gcs_loaders/qalert_requests_gcs.py
+++ b/af2_dags/dependencies/gcs_loaders/qalert_requests_gcs.py
@@ -30,7 +30,7 @@ run_start_win, first_run = find_last_successful_run(bucket, "requests/successful
 
 # qscend API requires a value (any value) for the user-agent field
 headers = {'User-Agent': 'City of Pittsburgh ETL'}
-payload = {'key': os.environ['QALERT_KEY'], 'since': "2022-08-22 00:00:00"} #run_start_win}
+payload = {'key': os.environ['QALERT_KEY'], 'since': run_start_win}
 
 
 # continue running the API until data is retrieved (wait 5 min if there is no new data between last_good_run and now (

--- a/af2_dags/dependencies/gcs_loaders/qalert_requests_gcs.py
+++ b/af2_dags/dependencies/gcs_loaders/qalert_requests_gcs.py
@@ -5,10 +5,8 @@ import argparse
 import requests
 import pendulum
 from datetime import datetime, timedelta
-import numpy as np
-from math import ceil
 
-from gcs_utils import json_to_gcs, replace_pii, find_last_successful_run
+from gcs_utils import json_to_gcs, find_last_successful_run
 
 API_LIMIT = 2000
 
@@ -55,68 +53,13 @@ while data_retrieved is False:
         time.sleep(300)
 
 
-# Comments must be scrubbed for PII from 311 requests.
-# Comments do not follow strict formatting so this is an imperfect approximation.
-# Steps: extract fields, detect person names that are followed by hotwords for exclusion (e.g. park or street),
-# place an underscore between the detected words to prevent accidental redaction, redact PII
-for row in full_requests:
-    row["comments"] = row["comments"] if row["comments"] != "" else "No comment"
-
-pre_clean = {"req_comments": []}
-for row in full_requests:
-    if row.get("comments", "") == "":
-        pre_clean["req_comments"].append("No comment")
-    else:
-        pre_clean["req_comments"].append(row.get("comments", "No comment"))
-
-
-# The Google data loss prevention (dlp) API is used (via helper function) to scrub PII. This API cannot handle
-# large payloads. We therefore chop the data into batches to prevent overloading the API. As of 11/2021 we use a
-# limit of 2000, but this can be modified by changing the 'API_LIMIT' constant.
-
-# determine the number of bins needed for each batch of comments (round up in case there is a remainder from the
-# division); split into batches
-bins = ceil(len(pre_clean["req_comments"]) / API_LIMIT)
-pre_clean_batches = np.array_split(pre_clean["req_comments"], bins)
-
-delim_seq = os.environ["DELIM"]
-all_comms = []
-for b in pre_clean_batches:
-    # convert list to string that is separated with a delimiter sequence (allows full list to be processed as one string,
-    # as opposed to mapping it to each element which is 100x slower)
-    batch = delim_seq.join(b)
-
-    # scrub pii
-    scrubbed_req_comments = replace_pii(batch, retain_location = True)
-
-    # convert delim-seperated string back to list of strings
-    split_req_comments = scrubbed_req_comments.split(delim_seq.strip())
-
-    # extend growing list with scrubbed comments
-    all_comms.extend(split_req_comments)
-
-
-# overwrite the original fields with scrubbed data
-success = False
-for i in range(len(full_requests)):
-    try:
-        full_requests[i]["comments"] = all_comms[i].strip()
-        success = True
-    except:
-        print("Error at ticket index #" + str(i))
-        print("Full request list length: " + str(len(full_requests)) + "| Scrubbed comment list length: " + str(len(all_comms)))
-        success = False
-        break
-
-
 # write the successful run information (used by each successive DAG run to find the backfill date)
-if success:
-    successful_run = [{"requests_retrieved": len(full_requests),
-                       "since": run_start_win,
-                       "current_run": curr_run,
-                       "note": "Data retrieved between the time points listed above"}]
-    json_to_gcs("requests/successful_run_log/log.json", successful_run,
-                bucket)
+successful_run = [{"requests_retrieved": len(full_requests),
+                   "since": run_start_win,
+                   "current_run": curr_run,
+                   "note": "Data retrieved between the time points listed above"}]
+json_to_gcs("requests/successful_run_log/log.json", successful_run,
+            bucket)
 
 # load to gcs
 json_to_gcs(args["out_loc"], full_requests, bucket)

--- a/af2_dags/dependencies/gcs_loaders/qalert_requests_gcs.py
+++ b/af2_dags/dependencies/gcs_loaders/qalert_requests_gcs.py
@@ -23,7 +23,7 @@ args = vars(parser.parse_args())
 # payload below
 yesterday = datetime.combine(datetime.now(tz = pendulum.timezone("utc")) - timedelta(1),
                              datetime.min.time()).strftime("%Y-%m-%d %H:%M:%S")
-run_start_win, first_run = find_last_successful_run(bucket, "requests/comment_refactor/successful_run_log/log.json", yesterday)
+run_start_win, first_run = find_last_successful_run(bucket, "requests/successful_run_log/log.json", yesterday)
 
 
 # qscend API requires a value (any value) for the user-agent field
@@ -58,7 +58,7 @@ successful_run = [{"requests_retrieved": len(full_requests),
                    "since": run_start_win,
                    "current_run": curr_run,
                    "note": "Data retrieved between the time points listed above"}]
-json_to_gcs("requests/comment_refactor/successful_run_log/log.json", successful_run,
+json_to_gcs("requests/successful_run_log/log.json", successful_run,
             bucket)
 
 # load to gcs

--- a/af2_dags/qalert_airflow.py
+++ b/af2_dags/qalert_airflow.py
@@ -59,7 +59,7 @@ dag = DAG(
 
 # initialize gcs locations
 bucket = f"gs://{os.environ['GCS_PREFIX']}_qalert"
-dataset = "requests"
+dataset = "requests/comment_refactor"
 
 path = "{{ ds|get_ds_year }}/{{ ds|get_ds_month }}/{{ ds|get_ds_day }}/{{ run_id }}"
 
@@ -86,7 +86,7 @@ dataflow = BashOperator(
 # Load AVRO data produced by dataflow_script into BQ temp table
 gcs_to_bq = GoogleCloudStorageToBigQueryOperator(
         task_id = 'gcs_to_bq',
-        destination_project_dataset_table = f"{os.environ['GCLOUD_PROJECT']}:qalert.incoming_actions",
+        destination_project_dataset_table = f"{os.environ['GCLOUD_PROJECT']}:qalert.comment_refactor_incoming_actions",
         bucket = f"{os.environ['GCS_PREFIX']}_qalert",
         source_objects = [f"{dataset}/{avro_loc}*.avro"],
         write_disposition = 'WRITE_TRUNCATE',
@@ -101,7 +101,7 @@ gcs_to_bq = GoogleCloudStorageToBigQueryOperator(
 # source of the error is instrinsic to dataflow and may not be fixable). Also, dedupe the results (someties the same
 # ticket appears in the computer system more than 1 time (a QAlert glitch)
 query_format_dedupe = f"""
-CREATE OR REPLACE TABLE `{os.environ['GCLOUD_PROJECT']}.qalert.incoming_actions` AS
+CREATE OR REPLACE TABLE `{os.environ['GCLOUD_PROJECT']}.qalert.comment_refactor_incoming_actions` AS
 WITH formatted  AS 
     (
     SELECT 
@@ -116,7 +116,7 @@ WITH formatted  AS
         CAST(google_anon_lat AS FLOAT64) AS google_anon_lat,
         CAST(google_anon_long AS FLOAT64) AS google_anon_long,
     FROM 
-        {os.environ['GCLOUD_PROJECT']}.qalert.incoming_actions
+        {os.environ['GCLOUD_PROJECT']}.qalert.comment_refactor_incoming_actions
     )
 -- drop the final column through slicing the string (-13). final column is added in next query     
 SELECT 
@@ -166,7 +166,7 @@ existing parent and it will change into a child ticket. This means the original 
 ticket. Future steps in the DAG will handle that possibility, and for this query the only feasible option is to assume
 the ticket is correctly labeled.*/
 
-INSERT INTO `{os.environ['GCLOUD_PROJECT']}.qalert.all_linked_requests`
+INSERT INTO `{os.environ['GCLOUD_PROJECT']}.qalert.comment_refactor_all_linked_requests`
 (
 SELECT
     id as group_id,
@@ -176,8 +176,8 @@ SELECT
     {LINKED_COLS_IN_ORDER}
 
 FROM
-    `{os.environ['GCLOUD_PROJECT']}.qalert.incoming_enriched`
-WHERE id NOT IN (SELECT id FROM `{os.environ['GCLOUD_PROJECT']}.qalert.all_tickets_current_status`)
+    `{os.environ['GCLOUD_PROJECT']}.qalert.comment_refactor_incoming_enriched`
+WHERE id NOT IN (SELECT id FROM `{os.environ['GCLOUD_PROJECT']}.qalert.comment_refactor_all_tickets_current_status`)
 AND child_ticket = False
 AND request_type_name NOT IN ({EXCLUDE_TYPES})
 );
@@ -204,19 +204,19 @@ along with the other child tickets
 */
 
 -- extract the newly identified child's information for integration in the next query
-CREATE OR REPLACE TABLE `{os.environ['GCLOUD_PROJECT']}.qalert.temp_prev_parent_now_child` AS
+CREATE OR REPLACE TABLE `{os.environ['GCLOUD_PROJECT']}.qalert.comment_refactor_temp_prev_parent_now_child` AS
 SELECT 
     id AS fp_id, parent_ticket_id, pii_comments, pii_private_notes
-FROM `{os.environ['GCLOUD_PROJECT']}.qalert.incoming_enriched`
+FROM `{os.environ['GCLOUD_PROJECT']}.qalert.comment_refactor_incoming_enriched`
 WHERE id IN (SELECT 
                 group_id
-             FROM`{os.environ['GCLOUD_PROJECT']}.qalert.all_linked_requests`)
+             FROM`{os.environ['GCLOUD_PROJECT']}.qalert.comment_refactor_all_linked_requests`)
 AND child_ticket = TRUE ;
 
 -- delete the false parent ticket's information 
-DELETE FROM `{os.environ['GCLOUD_PROJECT']}.qalert.all_linked_requests`
+DELETE FROM `{os.environ['GCLOUD_PROJECT']}.qalert.comment_refactor_all_linked_requests`
 WHERE group_id IN 
-        (SELECT fp_id FROM `{os.environ['GCLOUD_PROJECT']}.qalert.temp_prev_parent_now_child`);
+        (SELECT fp_id FROM `{os.environ['GCLOUD_PROJECT']}.qalert.comment_refactor_temp_prev_parent_now_child`);
 """
 remove_false_parents = BigQueryOperator(
         task_id = 'remove_false_parents',
@@ -243,7 +243,7 @@ the other newly identified children (those which were never associated with a fa
 Thus, the need to combine ALL OF THE CHILD TICKETS (both those associated with a false parent and those never being
 misrepresented) is handled by this query
 */
-CREATE OR REPLACE TABLE `{os.environ['GCLOUD_PROJECT']}.qalert.temp_child_combined` AS
+CREATE OR REPLACE TABLE `{os.environ['GCLOUD_PROJECT']}.qalert.comment_refactor_temp_child_combined` AS
 (
     -- children never seen before and without a false parent
     WITH new_children AS
@@ -251,8 +251,8 @@ CREATE OR REPLACE TABLE `{os.environ['GCLOUD_PROJECT']}.qalert.temp_child_combin
     SELECT
         id, parent_ticket_id, pii_comments, anon_comments, pii_private_notes
     FROM
-        `{os.environ['GCLOUD_PROJECT']}.qalert.incoming_enriched` new_c
-    WHERE new_c.id NOT IN (SELECT id FROM `{os.environ['GCLOUD_PROJECT']}.qalert.all_tickets_current_status`)
+        `{os.environ['GCLOUD_PROJECT']}.qalert.comment_refactor_incoming_enriched` new_c
+    WHERE new_c.id NOT IN (SELECT id FROM `{os.environ['GCLOUD_PROJECT']}.qalert.comment_refactor_all_tickets_current_status`)
     AND new_c.child_ticket = TRUE
     AND new_c.request_type_name NOT IN ({EXCLUDE_TYPES})
     ),
@@ -266,7 +266,7 @@ CREATE OR REPLACE TABLE `{os.environ['GCLOUD_PROJECT']}.qalert.temp_child_combin
     UNION ALL
 
     SELECT fp_id AS id, parent_ticket_id, pii_comments, anon_comments, pii_private_notes
-    FROM `{os.environ['GCLOUD_PROJECT']}.qalert.temp_prev_parent_now_child`
+    FROM `{os.environ['GCLOUD_PROJECT']}.qalert.comment_refactor_temp_prev_parent_now_child`
     ),
 
     -- from ALL children tickets, concatenate the necessary string data
@@ -302,29 +302,29 @@ CREATE OR REPLACE TABLE `{os.environ['GCLOUD_PROJECT']}.qalert.temp_child_combin
 );
 
 -- update existing entries inside all_linked_requests
-UPDATE `{os.environ['GCLOUD_PROJECT']}.qalert.all_linked_requests` alr
+UPDATE `{os.environ['GCLOUD_PROJECT']}.qalert.comment_refactor_all_linked_requests` alr
 SET alr.num_requests = tcc.cts + alr.num_requests
-FROM `{os.environ['GCLOUD_PROJECT']}.qalert.temp_child_combined` tcc
+FROM `{os.environ['GCLOUD_PROJECT']}.qalert.comment_refactor_temp_child_combined` tcc
 WHERE alr.group_id = tcc.p_id;
 
-UPDATE `{os.environ['GCLOUD_PROJECT']}.qalert.all_linked_requests` alr
+UPDATE `{os.environ['GCLOUD_PROJECT']}.qalert.comment_refactor_all_linked_requests` alr
 SET alr.child_ids =  CONCAT(alr.child_ids,tcc.child_ids)
-FROM `{os.environ['GCLOUD_PROJECT']}.qalert.temp_child_combined` tcc
+FROM `{os.environ['GCLOUD_PROJECT']}.qalert.comment_refactor_temp_child_combined` tcc
 WHERE alr.group_id = tcc.p_id;
 
-UPDATE `{os.environ['GCLOUD_PROJECT']}.qalert.all_linked_requests` alr
+UPDATE `{os.environ['GCLOUD_PROJECT']}.qalert.comment_refactor_all_linked_requests` alr
 SET alr.pii_comments =  CONCAT(alr.pii_comments,tcc.child_pii_comments)
-FROM `{os.environ['GCLOUD_PROJECT']}.qalert.temp_child_combined` tcc
+FROM `{os.environ['GCLOUD_PROJECT']}.qalert.comment_refactor_temp_child_combined` tcc
 WHERE alr.group_id = tcc.p_id;
 
-UPDATE `{os.environ['GCLOUD_PROJECT']}.qalert.all_linked_requests` alr
+UPDATE `{os.environ['GCLOUD_PROJECT']}.qalert.comment_refactor_all_linked_requests` alr
 SET alr.anon_comments =  CONCAT(alr.anon_comments,tcc.child_anon_comments)
-FROM `{os.environ['GCLOUD_PROJECT']}.qalert.temp_child_combined` tcc
+FROM `{os.environ['GCLOUD_PROJECT']}.qalert.comment_refactor_temp_child_combined` tcc
 WHERE alr.group_id = tcc.p_id;
 
-UPDATE `{os.environ['GCLOUD_PROJECT']}.qalert.all_linked_requests` alr
+UPDATE `{os.environ['GCLOUD_PROJECT']}.qalert.comment_refactor_all_linked_requests` alr
 SET alr.pii_private_notes =  CONCAT(alr.pii_private_notes,tcc.child_pii_notes)
-FROM `{os.environ['GCLOUD_PROJECT']}.qalert.temp_child_combined` tcc
+FROM `{os.environ['GCLOUD_PROJECT']}.qalert.comment_refactor_temp_child_combined` tcc
 WHERE alr.group_id = tcc.p_id;
 """
 integrate_children = BigQueryOperator(
@@ -353,7 +353,7 @@ changes to the child ticket. This query selects parent tickets which have been p
 simply extracts and updates the status timestamp data from those tickets. This data is then updated in
 all_linked_requests.
 */
-CREATE OR REPLACE TABLE  `{os.environ['GCLOUD_PROJECT']}.qalert.temp_update` AS
+CREATE OR REPLACE TABLE  `{os.environ['GCLOUD_PROJECT']}.qalert.comment_refactor_temp_update` AS
 (
 SELECT
     id,
@@ -361,56 +361,56 @@ SELECT
     closed_date_est, closed_date_utc,closed_date_unix,
     last_action_est, last_action_utc,last_action_unix,
     status_name, status_code
-FROM  `{os.environ['GCLOUD_PROJECT']}.qalert.incoming_enriched`
+FROM  `{os.environ['GCLOUD_PROJECT']}.qalert.comment_refactor_incoming_enriched`
 
-WHERE id IN (SELECT id FROM `{os.environ['GCLOUD_PROJECT']}.qalert.all_tickets_current_status`)
+WHERE id IN (SELECT id FROM `{os.environ['GCLOUD_PROJECT']}.qalert.comment_refactor_all_tickets_current_status`)
 AND child_ticket = FALSE
 AND request_type_name NOT IN ({EXCLUDE_TYPES})
 );
 
-UPDATE `{os.environ['GCLOUD_PROJECT']}.qalert.all_linked_requests` alr
+UPDATE `{os.environ['GCLOUD_PROJECT']}.qalert.comment_refactor_all_linked_requests` alr
 SET alr.parent_closed = tu.p_closed
-FROM `{os.environ['GCLOUD_PROJECT']}.qalert.temp_update` tu
+FROM `{os.environ['GCLOUD_PROJECT']}.qalert.comment_refactor_temp_update` tu
 WHERE alr.group_id = tu.id;
 
-UPDATE `{os.environ['GCLOUD_PROJECT']}.qalert.all_linked_requests` alr
+UPDATE `{os.environ['GCLOUD_PROJECT']}.qalert.comment_refactor_all_linked_requests` alr
 SET alr.status_name = tu.status_name
-FROM `{os.environ['GCLOUD_PROJECT']}.qalert.temp_update` tu
+FROM `{os.environ['GCLOUD_PROJECT']}.qalert.comment_refactor_temp_update` tu
 WHERE alr.group_id = tu.id;
 
-UPDATE `{os.environ['GCLOUD_PROJECT']}.qalert.all_linked_requests` alr
+UPDATE `{os.environ['GCLOUD_PROJECT']}.qalert.comment_refactor_all_linked_requests` alr
 SET alr.status_code = tu.status_code
-FROM `{os.environ['GCLOUD_PROJECT']}.qalert.temp_update` tu
+FROM `{os.environ['GCLOUD_PROJECT']}.qalert.comment_refactor_temp_update` tu
 WHERE alr.group_id = tu.id;
 
-UPDATE `{os.environ['GCLOUD_PROJECT']}.qalert.all_linked_requests` alr
+UPDATE `{os.environ['GCLOUD_PROJECT']}.qalert.comment_refactor_all_linked_requests` alr
 SET alr.closed_date_est = tu.closed_date_est
-FROM `{os.environ['GCLOUD_PROJECT']}.qalert.temp_update` tu
+FROM `{os.environ['GCLOUD_PROJECT']}.qalert.comment_refactor_temp_update` tu
 WHERE alr.group_id = tu.id;
 
-UPDATE `{os.environ['GCLOUD_PROJECT']}.qalert.all_linked_requests` alr
+UPDATE `{os.environ['GCLOUD_PROJECT']}.qalert.comment_refactor_comment_refactor_all_linked_requests` alr
 SET alr.closed_date_utc = tu.closed_date_utc
-FROM `{os.environ['GCLOUD_PROJECT']}.qalert.temp_update` tu
+FROM `{os.environ['GCLOUD_PROJECT']}.qalert.comment_refactor_temp_update` tu
 WHERE alr.group_id = tu.id;
 
-UPDATE `{os.environ['GCLOUD_PROJECT']}.qalert.all_linked_requests` alr
+UPDATE `{os.environ['GCLOUD_PROJECT']}.qalert.comment_refactor_all_linked_requests` alr
 SET alr.closed_date_unix = tu.closed_date_unix
-FROM `{os.environ['GCLOUD_PROJECT']}.qalert.temp_update` tu
+FROM `{os.environ['GCLOUD_PROJECT']}.qalert.comment_refactor_temp_update` tu
 WHERE alr.group_id = tu.id;
 
-UPDATE `{os.environ['GCLOUD_PROJECT']}.qalert.all_linked_requests` alr
+UPDATE `{os.environ['GCLOUD_PROJECT']}.qalert.comment_refactor_all_linked_requests` alr
 SET alr.last_action_est = tu.last_action_est
-FROM `{os.environ['GCLOUD_PROJECT']}.qalert.temp_update` tu
+FROM `{os.environ['GCLOUD_PROJECT']}.qalert.comment_refactor_temp_update` tu
 WHERE alr.group_id = tu.id;
 
-UPDATE `{os.environ['GCLOUD_PROJECT']}.qalert.all_linked_requests` alr
+UPDATE `{os.environ['GCLOUD_PROJECT']}.qalert.comment_refactor_all_linked_requests` alr
 SET alr.last_action_utc = tu.last_action_utc
-FROM `{os.environ['GCLOUD_PROJECT']}.qalert.temp_update` tu
+FROM `{os.environ['GCLOUD_PROJECT']}.qalert.comment_refactor_temp_update` tu
 WHERE alr.group_id = tu.id;
 
-UPDATE `{os.environ['GCLOUD_PROJECT']}.qalert.all_linked_requests` alr
+UPDATE `{os.environ['GCLOUD_PROJECT']}.qalert.comment_refactor_all_linked_requests` alr
 SET alr.last_action_unix = tu.last_action_unix
-FROM `{os.environ['GCLOUD_PROJECT']}.qalert.temp_update` tu
+FROM `{os.environ['GCLOUD_PROJECT']}.qalert.comment_refactor_temp_update` tu
 WHERE alr.group_id = tu.id;
 """
 replace_last_update = BigQueryOperator(
@@ -436,12 +436,12 @@ all_tickets_current_status is currently (01/22) maintained for historical purpos
 analysis as the linkages between tickets are not taken into account.
 */
 
-DELETE FROM `{os.environ['GCLOUD_PROJECT']}.qalert.all_tickets_current_status`
-WHERE id IN (SELECT id FROM `{os.environ['GCLOUD_PROJECT']}.qalert.incoming_enriched`);
-INSERT INTO `{os.environ['GCLOUD_PROJECT']}.qalert.all_tickets_current_status`
+DELETE FROM `{os.environ['GCLOUD_PROJECT']}.qalert.comment_refactor_all_tickets_current_status`
+WHERE id IN (SELECT id FROM `{os.environ['GCLOUD_PROJECT']}.qalert.comment_refactor_incoming_enriched`);
+INSERT INTO `{os.environ['GCLOUD_PROJECT']}.qalert.comment_refactor_all_tickets_current_status`
 SELECT 
     {COLS_IN_ORDER}
-FROM `{os.environ['GCLOUD_PROJECT']}.qalert.incoming_enriched`;
+FROM `{os.environ['GCLOUD_PROJECT']}.qalert.comment_refactor_incoming_enriched`;
 """
 delete_old_insert_new_records = BigQueryOperator(
         task_id = 'delete_old_insert_new_records',
@@ -455,7 +455,7 @@ delete_old_insert_new_records = BigQueryOperator(
 # subsequently exported to WPRDC. BQ will not currently (2021-10-01) allow data to be pushed from a query and it must
 # be stored in a table prior to the push. Thus, this is a 2 step process also involving the operator below.
 query_drop_pii = f"""
-CREATE OR REPLACE TABLE `{os.environ['GCLOUD_PROJECT']}.qalert.data_export_scrubbed` AS
+CREATE OR REPLACE TABLE `{os.environ['GCLOUD_PROJECT']}.qalert.comment_refactor_data_export_scrubbed` AS
 SELECT
     group_id,
     child_ids,
@@ -463,7 +463,7 @@ SELECT
     parent_closed,
     {SAFE_FIELDS}
 FROM
-    `{os.environ['GCLOUD_PROJECT']}.qalert.all_linked_requests`
+    `{os.environ['GCLOUD_PROJECT']}.qalert.comment_refactor_all_linked_requests`
 """
 drop_pii_for_export = BigQueryOperator(
         task_id = 'drop_pii_for_export',
@@ -476,7 +476,7 @@ drop_pii_for_export = BigQueryOperator(
 # Export table as CSV to WPRDC bucket
 wprdc_export = BigQueryToCloudStorageOperator(
         task_id = 'wprdc_export',
-        source_project_dataset_table = f"{os.environ['GCLOUD_PROJECT']}.qalert.data_export_scrubbed",
+        source_project_dataset_table = f"{os.environ['GCLOUD_PROJECT']}.qalert.comment_refactor_data_export_scrubbed",
         destination_cloud_storage_uris = [f"gs://{os.environ['GCS_PREFIX']}_wprdc/qalert_requests/{path}.csv"],
         bigquery_conn_id='google_cloud_default',
         dag = dag

--- a/af2_dags/qalert_airflow.py
+++ b/af2_dags/qalert_airflow.py
@@ -133,7 +133,7 @@ format_dedupe = BigQueryOperator(
 )
 
 # Query new tickets to determine if they are in the city limits
-query_city_lim = build_city_limits_query('qalert', 'incoming_actions', 'input_pii_lat', 'input_pii_long')
+query_city_lim = build_city_limits_query('qalert', 'comment_refactor_incoming_actions', 'input_pii_lat', 'input_pii_long')
 city_limits = BigQueryOperator(
         task_id = 'city_limits',
         sql = query_city_lim,
@@ -146,7 +146,7 @@ city_limits = BigQueryOperator(
 #  for clearer explanation)
 # FINAL ENRICHMENT OF NEW DATA
 # Join all the geo information (e.g. DPW districts, etc) to the new data
-query_geo_join = build_revgeo_time_bound_query('qalert', 'incoming_actions', "incoming_enriched",
+query_geo_join = build_revgeo_time_bound_query('qalert', 'comment_refactor_incoming_actions', 'comment_refactor_incoming_enriched',
                                                'create_date_utc', 'id', 'input_pii_lat', 'input_pii_long')
 geojoin = BigQueryOperator(
         task_id = 'geojoin',

--- a/af2_dags/qalert_airflow.py
+++ b/af2_dags/qalert_airflow.py
@@ -19,7 +19,7 @@ from dependencies.airflow_utils import get_ds_year, get_ds_month, get_ds_day, de
 
 COLS_IN_ORDER = """id, parent_ticket_id, child_ticket, dept, status_name, status_code, request_type_name, 
 request_type_id, origin, pii_comments, anon_comments, pii_private_notes, create_date_est, create_date_utc, 
-create_date_unix, , last_action_est, last_action_utc, last_action_unix, closed_date_est, closed_date_utc, 
+create_date_unix, last_action_est, last_action_utc, last_action_unix, closed_date_est, closed_date_utc, 
 closed_date_unix, pii_street_num, street, cross_street, street_id, cross_street_id, city, pii_input_address, 
 pii_google_formatted_address, anon_google_formatted_address, address_type, neighborhood_name, 
 council_district, ward, police_zone, fire_zone, dpw_streets, dpw_enviro, dpw_parks, input_pii_lat, input_pii_long, 

--- a/af2_dags/qalert_lat_long_backfill_airflow.py
+++ b/af2_dags/qalert_lat_long_backfill_airflow.py
@@ -114,7 +114,7 @@ CREATE OR REPLACE TABLE `{os.environ['GCLOUD_PROJECT']}.qalert.all_linked_reques
 SELECT 
     group_id, child_ids, num_requests, parent_closed, status_name, 
     status_code, dept, request_type_name, request_type_id, origin,
-    pii_comments, pii_private_notes, create_date_est, create_date_utc, 
+    anon_comments, pii_private_notes, create_date_est, create_date_utc, 
     create_date_unix, last_action_est, last_action_utc, last_action_unix, 
     closed_date_est, closed_date_utc, closed_date_unix, pii_street_num, 
     street, cross_street, street_id, cross_street_id, city, 
@@ -133,7 +133,7 @@ CREATE OR REPLACE TABLE `{os.environ['GCLOUD_PROJECT']}.qalert.all_tickets_curre
 SELECT 
     atcs.id, atcs.parent_ticket_id, atcs.child_ticket, dept, status_name, 
     status_code, request_type_name, request_type_id, origin,
-    pii_comments, pii_private_notes, create_date_est, create_date_utc, 
+    anon_comments, pii_private_notes, create_date_est, create_date_utc, 
     create_date_unix, last_action_est, last_action_utc, last_action_unix, 
     closed_date_est, closed_date_utc, closed_date_unix, pii_street_num, 
     street, cross_street, street_id, cross_street_id, city, 

--- a/tests/test_dataflow_utils.py
+++ b/tests/test_dataflow_utils.py
@@ -161,6 +161,7 @@ class TestDataflowUtils(unittest.TestCase):
         datum = [{'comments': 'remove pothole'},
                  {'comments': 'John Doe is causing a lot of noise'},
                  {'comments': 'plow snow on Smith St and on 1st and Murray, notify me at jdoe@email.com when done'},
+                 {'comments': ''},
                  {'comments': 'I saw Ms. Smith littering'},
                  {'comments': 'Timmy Smith woke up the whole neighborhood by listening to The Smiths too loud. Call him at 412-111-2222 to make him stop'}]
         input_field = 'comments'
@@ -172,12 +173,14 @@ class TestDataflowUtils(unittest.TestCase):
                      'anon_comments': '[PERSON_NAME] is causing a lot of noise'},
                     {'comments': 'plow snow on Smith St and on 1st and Murray, notify me at jdoe@email.com when done',
                      'anon_comments': 'plow snow on Smith_St and on 1st and_Murray, notify me at [EMAIL_ADDRESS] when done'},
+                    {'comments': '',
+                     'anon_comments': 'No comment'},
                     {'comments': 'I saw Ms. Smith littering',
                      'anon_comments': 'I saw [PERSON_NAME] littering'},
                     {'comments': 'Timmy Smith woke up the whole neighborhood by listening to The Smiths too loud. Call him at 412-111-2222 to make him stop',
                      'anon_comments': '[PERSON_NAME] woke up the whole neighborhood by listening to The Smiths too loud. Call him at [PHONE_NUMBER] to make him stop'}]
 
-        rp = dataflow_utils.ReplacePII(input_field, new_field_name, retain_location, info_types)
+        rp = dataflow_utils.ReplacePII(input_field, new_field_name, retain_location, info_types, 'data-rivers-testing', 'user_defined_data')
         results = []
         for val in datum:
             result = next(rp.process(val))

--- a/tests/test_dataflow_utils.py
+++ b/tests/test_dataflow_utils.py
@@ -157,7 +157,7 @@ class TestDataflowUtils(unittest.TestCase):
         ff = dataflow_utils.FilterFields(relevant_fields, exclude_relevant_fields=False)
         self.assertEqual(next(ff.process(datum)), expected)
 
-    def test_remove_pii(self):
+    def test_replace_pii(self):
         datum = [{'comments': 'remove pothole'},
                  {'comments': 'John Doe is causing a lot of noise'},
                  {'comments': 'plow snow on Smith St and on 1st and Murray, notify me at jdoe@email.com when done'},
@@ -177,7 +177,7 @@ class TestDataflowUtils(unittest.TestCase):
                     {'comments': 'Timmy Smith woke up the whole neighborhood by listening to The Smiths too loud. Call him at 412-111-2222 to make him stop',
                      'anon_comments': '[PERSON_NAME] woke up the whole neighborhood by listening to The Smiths too loud. Call him at [PHONE_NUMBER] to make him stop'}]
 
-        rp = dataflow_utils.RemovePII(input_field, new_field_name, retain_location, info_types)
+        rp = dataflow_utils.ReplacePII(input_field, new_field_name, retain_location, info_types)
         results = []
         for val in datum:
             result = next(rp.process(val))

--- a/tests/test_dataflow_utils.py
+++ b/tests/test_dataflow_utils.py
@@ -9,8 +9,8 @@ import numpy as np
 import requests
 import pytz
 
-import dataflow_utils
-from af2_dags.dependencies.dataflow_scripts.dataflow_utils import dataflow_utils as af2_dataflow_utils
+#import dataflow_utils
+from af2_dags.dependencies.dataflow_scripts.dataflow_utils import dataflow_utils# as af2_dataflow_utils
 from numpy import random
 
 
@@ -52,14 +52,14 @@ class TestDataflowUtils(unittest.TestCase):
         expected = {'bool_1': True, 'bool_2': False,
                     'bool_3': False, 'bool_4': True,
                     'bool_5': 'N/A', 'bool_6': False}
-        cb = af2_dataflow_utils.ConvertBooleans(bool_changes, include_defaults = False)
+        cb = dataflow_utils.ConvertBooleans(bool_changes, include_defaults = False)
         self.assertEqual(next(cb.process(datum)), expected)
 
     def test_filter_outliers(self):
         datum = {"num_bridges": 446, "num_super_bowls": 6}
         outliers_conv = [("num_bridges", 1, 445), ("num_super_bowls", 6, 9999)]
         expected = {"num_bridges": None, "num_super_bowls": 6}
-        fo = af2_dataflow_utils.FilterOutliers(outliers_conv)
+        fo = dataflow_utils.FilterOutliers(outliers_conv)
         self.assertEqual(next(fo.process(datum)), expected)
 
     def test_google_maps_classify_and_geocode(self):
@@ -156,6 +156,33 @@ class TestDataflowUtils(unittest.TestCase):
         expected = {'state': 'pa'}
         ff = dataflow_utils.FilterFields(relevant_fields, exclude_relevant_fields=False)
         self.assertEqual(next(ff.process(datum)), expected)
+
+    def test_remove_pii(self):
+        datum = [{'comments': 'remove pothole'},
+                 {'comments': 'John Doe is causing a lot of noise'},
+                 {'comments': 'plow snow on Smith St and on 1st and Murray, notify me at jdoe@email.com when done'},
+                 {'comments': 'I saw Ms. Smith littering'},
+                 {'comments': 'Timmy Smith woke up the whole neighborhood by listening to The Smiths too loud. Call him at 412-111-2222 to make him stop'}]
+        input_field = 'comments'
+        new_field_name = 'anon_comments'
+        retain_location = True
+        info_types = [{"name": "PERSON_NAME"}, {"name": "EMAIL_ADDRESS"}, {"name": "PHONE_NUMBER"}]
+        expected = [{'comments': 'remove pothole', 'anon_comments': 'remove pothole'},
+                    {'comments': 'John Doe is causing a lot of noise',
+                     'anon_comments': '[PERSON_NAME] is causing a lot of noise'},
+                    {'comments': 'plow snow on Smith St and on 1st and Murray, notify me at jdoe@email.com when done',
+                     'anon_comments': 'plow snow on Smith_St and on 1st and_Murray, notify me at [EMAIL_ADDRESS] when done'},
+                    {'comments': 'I saw Ms. Smith littering',
+                     'anon_comments': 'I saw [PERSON_NAME] littering'},
+                    {'comments': 'Timmy Smith woke up the whole neighborhood by listening to The Smiths too loud. Call him at 412-111-2222 to make him stop',
+                     'anon_comments': '[PERSON_NAME] woke up the whole neighborhood by listening to The Smiths too loud. Call him at [PHONE_NUMBER] to make him stop'}]
+
+        rp = dataflow_utils.RemovePII(input_field, new_field_name, retain_location, info_types)
+        results = []
+        for val in datum:
+            result = next(rp.process(val))
+            results.append(result)
+        self.assertEqual(results, expected)
 
     def test_standardize_times(self):
         """


### PR DESCRIPTION
Too many errors were occurring in the Qalert GCS Loader due to the comment PII scrubber function. This branch switches the location into the Dataflow script, which avoids some of the processing issues we were facing previously. It additionally gives us 2 comment fields - pii_comments and anon_comments, one with PII and one with it scrubbed. All final analysis tables will only contain scrubbed comments.