### PR TITLE
Fix Error Causing DAG to Crash on 1st of Each Month

### DIFF
--- a/af2_dags/dependencies/airflow_utils.py
+++ b/af2_dags/dependencies/airflow_utils.py
@@ -76,7 +76,19 @@ def get_ds_month(ds):
     return ds.split('-')[1]
 
 
-def get_ds_day(ds):
+def get_ds_day(prev_ds):
+    return prev_ds.split('-')[2]
+
+
+def get_prev_ds_year(prev_ds):
+    return prev_ds.split('-')[0]
+
+
+def get_prev_ds_month(prev_ds):
+    return prev_ds.split('-')[1]
+
+
+def get_prev_ds_day(ds):
     return ds.split('-')[2]
 
 

--- a/af2_dags/prev_day_weather_airflow.py
+++ b/af2_dags/prev_day_weather_airflow.py
@@ -8,7 +8,7 @@ from airflow.operators.bash_operator import BashOperator
 from airflow.contrib.operators.bigquery_operator import BigQueryOperator
 from airflow.contrib.operators.gcs_to_bq import GoogleCloudStorageToBigQueryOperator
 from dependencies import airflow_utils
-from dependencies.airflow_utils import get_ds_month, get_ds_year, default_args
+from dependencies.airflow_utils import get_prev_ds_month, get_prev_ds_year, default_args
 
 import pendulum
 import pytz
@@ -22,13 +22,13 @@ dag = DAG(
     default_args=default_args,
     start_date=pendulum.datetime(2022, 9, 23, 0, 1, tz=pytz.timezone('US/Eastern')),
     schedule_interval='0 0 * * *',
-    user_defined_filters={'get_ds_month': get_ds_month, 'get_ds_year': get_ds_year}
+    user_defined_filters={'get_prev_ds_month': get_prev_ds_month, 'get_prev_ds_year': get_prev_ds_year}
 )
 
 # initialize gcs locations
 dataset = "weather"
 bucket = f"{os.environ['GCS_PREFIX']}_{dataset}"
-path = "{{ ds|get_ds_year }}/{{ ds|get_ds_month }}"
+path = "{{ prev_ds|get_prev_ds_year }}/{{ prev_ds|get_prev_ds_month }}"
 
 prev_day_weather_gcs = BashOperator(
     task_id='prev_day_weather_gcs',


### PR DESCRIPTION
Due to a configuration flaw where the GoogleCloudStorageToBigQueryOperator looked to a subdirectory for the current month, the DAG was crashing on the first day of every month. This is because the operator was looking in the current month's folder and not the previous month if it was capturing the weather report for the previous day that happened to fall in a different month.