### PR TITLE
Prevent KeyErrors in SwapFieldNames Util Function

### DIFF
--- a/af2_dags/dependencies/dataflow_scripts/dataflow_utils/dataflow_utils.py
+++ b/af2_dags/dependencies/dataflow_scripts/dataflow_utils/dataflow_utils.py
@@ -579,7 +579,11 @@ class SwapFieldNames(beam.DoFn, ABC):
                 datum[name_change[1]] = datum[name_change[0]]
                 del datum[name_change[0]]
             except TypeError:
-                print(name_change[0] + " and " + name_change[1] + " were not both found within datum")
+                print(f"{name_change[0]} and {name_change[1]} were not both found within datum")
+                datum[name_change[1]] = None
+            except KeyError:
+                print(f"{name_change[0]} not found as a field within datum")
+                datum[name_change[1]] = None
 
         yield datum
 


### PR DESCRIPTION
The InTime DAG experienced a dataflow failure stemming from the SwapFieldNames utility function. After some investigation, it turned out that KeyErrors occur within the function if a field whose name we are trying to swap is missing from a row of the datum. This change addresses this issue by handling the exception, printing a message to the console, and setting the value of the new field to None.