### PR TITLE
Handle Ceridian Dept Name Mismatch Issue

### DIFF
--- a/af2_dags/dependencies/dataflow_scripts/ceridian_dataflow.py
+++ b/af2_dags/dependencies/dataflow_scripts/ceridian_dataflow.py
@@ -48,6 +48,14 @@ class CrosswalkDeptNames(beam.DoFn):
                 datum['dept_desc'] = dict['Department Description']
                 datum['office'] = dict['Office']
                 datum['corporation'] = dict['Corporation']
+        if datum['dept'] == '':
+            split_dept = datum['Department_ShortName'].split("-")
+            datum['dept'] = split_dept[0]
+            try:
+                datum['dept_desc'] = split_dept[1]
+            except:
+                datum['dept_desc'] = split_dept[0]
+            datum['corporation'] = 'City of Pittsburgh'
         yield datum
 
 


### PR DESCRIPTION
Sometimes, Ceridian assigns new department names to employees that have not previously appeared in our crosswalk file.
This fix handles cases where there is a new unrecognized department names. Previously, if no department name match was found, the values of the department columns would be left blank. This fix temporarily keeps the (uncleaned) department name provided by the Ceridian API so that the department column will not be left blank in the final BQ table.