### PR TITLE
Prepend 0s to ID Vals Under 6 Characters Long

### DIFF
--- a/af2_dags/dependencies/dataflow_scripts/dataflow_utils/dataflow_utils.py
+++ b/af2_dags/dependencies/dataflow_scripts/dataflow_utils/dataflow_utils.py
@@ -460,6 +460,23 @@ class GeocodeAddress(beam.DoFn, ABC):
         yield datum
 
 
+class PrependCharacters(beam.DoFn, ABC):
+    def __init__(self, input_field, length, char='0'):
+        self.input_field = input_field
+        self.length = length
+        self.char = char
+
+    def process(self, datum):
+        if datum[self.input_field]:
+            id_str = str(datum[self.input_field])
+            if id_str not in ('nan', 'None', 'null'):
+                while len(id_str) < self.length:
+                    id_str = self.char + id_str
+            datum[self.input_field] = id_str
+
+        yield datum
+
+
 class ReformatPhoneNumbers(beam.DoFn, ABC):
     """
     Method to standardize phone number format according to North American Number Plan.

--- a/af2_dags/dependencies/dataflow_scripts/intime_dataflow.py
+++ b/af2_dags/dependencies/dataflow_scripts/intime_dataflow.py
@@ -9,7 +9,7 @@ from apache_beam.io.avroio import WriteToAvro
 
 from dataflow_utils import dataflow_utils
 from dataflow_utils.dataflow_utils import JsonCoder, SwapFieldNames, generate_args, FilterFields, \
-    ColumnsCamelToSnakeCase, ChangeDataTypes, ExtractFieldWithComplexity
+    ColumnsCamelToSnakeCase, ChangeDataTypes, ExtractFieldWithComplexity, PrependCharacters
 
 DEFAULT_DATAFLOW_ARGS = [
         '--save_main_session',
@@ -44,7 +44,8 @@ def run(argv = None):
         additional_search_vals = ['pittsburghpa.gov', '', '', '', '', '', '', '']
         field_name_swaps = [('middle_name', 'middle_initial'), ('external_id', 'mpoetc_number'),
                             ('other_id', 'badge_number'), ('anniversary_date', 'hire_date')]
-        type_changes = [('employee_id', 'str')]
+        id_field = 'employee_id'
+        type_changes = [(id_field, 'str')]
         keep_fields = ['employee_id', 'mpoetc_number', 'badge_number', 'first_name', 'middle_initial', 'last_name',
                        'display_name', 'email', 'birth_date', 'hire_date', 'rank', 'rank_valid_date', 'unit',
                        'unit_valid_date', 'race', 'gender', 'employee_type']
@@ -58,6 +59,7 @@ def run(argv = None):
                 | beam.ParDo(ColumnsCamelToSnakeCase())
                 | beam.ParDo(SwapFieldNames(field_name_swaps))
                 | beam.ParDo(ChangeDataTypes(type_changes))
+                | beam.ParDo(PrependCharacters(id_field, 6))
                 | beam.ParDo(FilterFields(keep_fields, exclude_target_fields=False))
                 | WriteToAvro(known_args.avro_output, schema = avro_schema, file_name_suffix = '.avro',
                               use_fastavro = True)

--- a/tests/test_dataflow_utils.py
+++ b/tests/test_dataflow_utils.py
@@ -244,6 +244,18 @@ class TestDataflowUtils(unittest.TestCase):
         ff = dataflow_utils.FilterFields(relevant_fields, exclude_relevant_fields=False)
         self.assertEqual(next(ff.process(datum)), expected)
 
+    def test_prepend_characters(self):
+        datum = [{'id': '13342'}, {'id': '312258'}, {'id': '8070'}, {'id': None}, {'id': '2'}]
+        input_field = 'id'
+        length = 6
+        expected = [{'id': '013342'}, {'id': '312258'}, {'id': '008070'}, {'id': None}, {'id': '000002'}]
+        pc = dataflow_utils.PrependCharacters(input_field, length)
+        results = []
+        for val in datum:
+            result = next(pc.process(val))
+            results.append(result)
+        self.assertEqual(results, expected)
+
     def test_replace_pii(self):
         datum = [{'comments': 'remove pothole'},
                  {'comments': 'John Doe is causing a lot of noise'},


### PR DESCRIPTION
Ceridian ID values occasionally come through in the InTime data as under the required 6 characters long in cases where the ID has preceeding 0s. This branch adds a dataflow util that adds these 0s (or any other character you choose) back to the front of ID values that are below a certain length