### PR TITLE
Fix str.zfill() Error

### DIFF
--- a/af2_dags/dependencies/dataflow_scripts/dataflow_utils/pandas_utils.py
+++ b/af2_dags/dependencies/dataflow_scripts/dataflow_utils/pandas_utils.py
@@ -79,6 +79,7 @@ def change_data_type(df, convs):
 
 
 def fill_leading_zeroes(df, field_name, digits):
+    df[field_name] = df[field_name].astype(str)
     df[field_name] = df[field_name].str.zfill(digits)
     return df
 


### PR DESCRIPTION
The DAG was failing during the pandas stage because of the following error:
AttributeError("Can only use .str accessor with string values!")
This fix adds a line of code before the str.zfill function call in the fill_leading_zeroes util function that converts
the whole Pandas dataframe column to string type before attempting to use the zfill function