### PR TITLE
Add Parameter to GCS Loader Task to Auto-Fail After Hour of Runtime

### DIFF
--- a/af2_dags/intime_employees_airflow.py
+++ b/af2_dags/intime_employees_airflow.py
@@ -33,6 +33,7 @@ avro_loc = f"avro_output/{path}/"
 intime_gcs = BashOperator(
     task_id='intime_gcs',
     bash_command=f"python {os.environ['GCS_LOADER_PATH']}/intime_employees_gcs.py --output_arg {json_loc}",
+    execution_timeout=timedelta(hours=1),
     dag=dag
 )
 


### PR DESCRIPTION
A previous run of the InTime DAG ran for 88 hours in the GCS loader phase but did not complete or fail, preventing future runs from executing. This branch adds an execution_timeout parameter to the GCS loader task within the Airflow script to prevent this issue from repeating in the future.