### PR TITLE
Remove References to Redundant GCS Bucket

### DIFF
--- a/af2_dags/ceridian_employees_airflow.py
+++ b/af2_dags/ceridian_employees_airflow.py
@@ -37,20 +37,20 @@ path = "{{ ds|get_ds_year }}/{{ ds|get_ds_month }}"
 json_loc = f"{dataset}/{path}/{exec_date}_employees.json"
 avro_loc = f"{dataset}/avro_output/{path}/" + "{{ run_id }}"
 
-ceridian_gcs = BashOperator(
+ceridian_employees_gcs = BashOperator(
     task_id='ceridian_employees_gcs',
     bash_command=f"python {os.environ['GCS_LOADER_PATH']}/ceridian_employees_gcs.py --output_arg {json_loc}",
     dag=dag
 )
 
-ceridian_dataflow = BashOperator(
+ceridian_employees_dataflow = BashOperator(
     task_id='ceridian_employees_dataflow',
     bash_command=f"python {os.environ['DATAFLOW_SCRIPT_PATH']}/ceridian_employees_dataflow.py "
                  f"--input {bucket}/{json_loc} --avro_output {bucket}/{avro_loc}",
     dag=dag
 )
 
-ceridian_bq_load = GoogleCloudStorageToBigQueryOperator(
+ceridian_employees_bq_load = GoogleCloudStorageToBigQueryOperator(
     task_id='ceridian_employees_bq_load',
     destination_project_dataset_table=f"{os.environ['GCLOUD_PROJECT']}.ceridian.all_employees",
     bucket=f"{os.environ['GCS_PREFIX']}_ceridian",
@@ -116,5 +116,5 @@ beam_cleanup = BashOperator(
     dag=dag
 )
 
-ceridian_gcs >> ceridian_dataflow >> ceridian_bq_load >> create_gender_comp_table >> create_racial_comp_table >> \
-    ceridian_iapro_export >> beam_cleanup
+ceridian_employees_gcs >> ceridian_employees_dataflow >> ceridian_employees_bq_load >> create_gender_comp_table >> \
+    create_racial_comp_table >> ceridian_iapro_export >> beam_cleanup

--- a/af2_dags/ceridian_employees_airflow.py
+++ b/af2_dags/ceridian_employees_airflow.py
@@ -101,15 +101,7 @@ create_racial_comp_table = BigQueryOperator(
     dag=dag
 )
 
-# Export employee table to Ceridian bucket as readable CSV
-ceridian_export = BigQueryToCloudStorageOperator(
-    task_id='ceridian_export',
-    source_project_dataset_table=f"{os.environ['GCLOUD_PROJECT']}.ceridian.all_employees",
-    destination_cloud_storage_uris=[f"gs://{os.environ['GCS_PREFIX']}_shared/ceridian_report.csv"],
-    bigquery_conn_id='google_cloud_default',
-    dag=dag
-)
-
+# Export employee table to IAPro bucket as readable CSV
 ceridian_iapro_export = BigQueryToCloudStorageOperator(
     task_id='ceridian_iapro_export',
     source_project_dataset_table=f"{os.environ['GCLOUD_PROJECT']}.ceridian.all_employees",
@@ -125,4 +117,4 @@ beam_cleanup = BashOperator(
 )
 
 ceridian_gcs >> ceridian_dataflow >> ceridian_bq_load >> create_gender_comp_table >> create_racial_comp_table >> \
-    ceridian_export >> ceridian_iapro_export >> beam_cleanup
+    ceridian_iapro_export >> beam_cleanup

--- a/af2_dags/dependencies/dataflow_scripts/ceridian_employees_dataflow.py
+++ b/af2_dags/dependencies/dataflow_scripts/ceridian_employees_dataflow.py
@@ -35,7 +35,7 @@ def run(argv=None):
     # and avro schema to validate data with. Return the arg parser values, PipelineOptions, and avro_schemas (dict)
 
     known_args, pipeline_options, avro_schema = generate_args(
-        job_name='ceridian-dataflow',
+        job_name='ceridian-employees-dataflow',
         bucket=f"{os.environ['GCS_PREFIX']}_ceridian",
         argv=argv,
         schema_name='ceridian_employees',

--- a/af2_dags/dependencies/dataflow_scripts/ceridian_timekeeping_dataflow.py
+++ b/af2_dags/dependencies/dataflow_scripts/ceridian_timekeeping_dataflow.py
@@ -26,7 +26,7 @@ def run(argv=None):
     # and avro schema to validate data with. Return the arg parser values, PipelineOptions, and avro_schemas (dict)
 
     known_args, pipeline_options, avro_schema = generate_args(
-        job_name='ceridian-dataflow',
+        job_name='ceridian-timekeeping-dataflow',
         bucket=f"{os.environ['GCS_PREFIX']}_ceridian",
         argv=argv,
         schema_name='ceridian_timekeeping',

--- a/af2_dags/intime_employees_airflow.py
+++ b/af2_dags/intime_employees_airflow.py
@@ -43,15 +43,7 @@ intime_pandas = BashOperator(
     dag=dag
 )
 
-# Export table to InTime bucket as readable CSV
-intime_export = BigQueryToCloudStorageOperator(
-    task_id='intime_export',
-    source_project_dataset_table=f"{os.environ['GCLOUD_PROJECT']}.{dataset}.employee_data",
-    destination_cloud_storage_uris=[f"gs://{os.environ['GCS_PREFIX']}_shared/intime_report.csv"],
-    bigquery_conn_id='google_cloud_default',
-    dag=dag
-)
-
+# Export table to IAPro bucket as readable CSV
 intime_iapro_export = BigQueryToCloudStorageOperator(
     task_id='intime_iapro_export',
     source_project_dataset_table=f"{os.environ['GCLOUD_PROJECT']}.{dataset}.employee_data",
@@ -60,4 +52,4 @@ intime_iapro_export = BigQueryToCloudStorageOperator(
     dag=dag
 )
 
-intime_gcs >> intime_pandas >> intime_export >> intime_iapro_export
+intime_gcs >> intime_pandas >> intime_iapro_export


### PR DESCRIPTION
All data sharing of InTime and Ceridian data will now be sourced from the iapro bucket rather than the shared bucket, which contained identical data anyway. The bucket can be deleted after these changes are deployed