### PR TITLE
timeout in api call was hardcoded (despite a variable for this in the…

### DIFF
--- a/af2_dags/dependencies/gcs_loaders/gcs_utils.py
+++ b/af2_dags/dependencies/gcs_loaders/gcs_utils.py
@@ -88,7 +88,7 @@ def call_odata_api_error_handling(targ_url, pipeline, time_out = 3600, limit_res
         # try the call
         try:
             print(F"executing call #{call_attempt}")
-            res = requests.get(targ_url, timeout = 300)
+            res = requests.get(targ_url, timeout = time_out)
 
 
         # exceptions for calls that are never executed or completed w/in time limit


### PR DESCRIPTION
… input args). switched the api call to using the variable instead